### PR TITLE
Force re-integrate LDAP groups in case they're missing.

### DIFF
--- a/functions/idvtoauth0/authzero.py
+++ b/functions/idvtoauth0/authzero.py
@@ -13,6 +13,7 @@
 # create:users (for users Auth0 does not yet know about)
 # update:user_app_metadata (this is where the CIS data is stored)
 # create:user_app_metadata (same reason)
+# read:users (to read the original user data for [re]integration purposes)
 #
 # NOTE: we're not using update:users because it is not possible to update
 # the attributes we care about directly. Instead we load the attributes we
@@ -63,6 +64,23 @@ class CISAuthZero():
     def __del__(self):
         self.client_secret = None
         self.conn.close()
+
+    def get_user(self, user_id):
+        """
+        user_id: string
+        returns: JSON dict of the user profile
+        """
+
+        payload = DotDict(dict())
+        payload_json = json.dumps(payload)
+        self.conn.request("GET",
+                          "/api/v2/users/{}".format(user_id),
+                          payload_json,
+                          self._authorize(self.default_headers))
+        res = self.conn.getresponse()
+        self._check_http_response(res)
+        user = DotDict(json.loads(res.read()))
+        return user
 
     def update_user(self, user_id, new_profile):
         """

--- a/functions/idvtoauth0/main.py
+++ b/functions/idvtoauth0/main.py
@@ -70,6 +70,17 @@ def handle(event, context):
         logger.info("Status of profile search is {s}".format(s=profile))
 
         if profile is not None:
+            # XXX Force-integrate LDAP groups as these are synchronized
+            # from LDAP to Auth0 directly.
+            # This is to be removed when LDAP feeds CIS.
+            upstream_user = client.get_user(user_id)
+
+            if 'groups' in upstream_user.keys():
+                for g in upstream_user['groups']:
+                    if g not in profile['groups']:
+                        profile['groups'].append(g)
+                        logger.info("Forced re-integration of LDAP group {}".format(g))
+
             res = client.update_user(user_id, profile)
             logger.info("Status of message processing is {s}".format(s=res))
         else:


### PR DESCRIPTION
This is because LDAP syncs with Auth0 today, instead of CIS
This commit can be reverted when LDAP publishes to CIS instead.

NOTE: Some users may not have LDAP group data, in which case it's
ignored. If users have any other 'groups' attribute comming from an IdP
it will ALSO be force-integrated, just like LDAP.