### PR TITLE
Only integrate CIS profiles that are part of the cis_whitelist

### DIFF
--- a/functions/idvtoauth0/main.py
+++ b/functions/idvtoauth0/main.py
@@ -70,6 +70,12 @@ def handle(event, context):
         logger.info("Status of profile search is {s}".format(s=profile))
 
         if profile is not None:
+            # Profile whitelisting. This allows to select which user profiles are
+            # to be integrated using CIS, mainly for transitioning purposes.
+            # See also: https://mozillians.org/en-US/group/cis_whitelist
+            if 'mozilliansorg_cis_whitelist' not in profile['groups']:
+                continue
+
             # XXX Force-integrate LDAP groups as these are synchronized
             # from LDAP to Auth0 directly.
             # This is to be removed when LDAP feeds CIS.


### PR DESCRIPTION
Mozillians group
See also https://mozillians.org/en-US/group/cis_whitelist

NOTE: this also needs a reintegration OR validator that ensure mozilliansorg groups are namespaced in the group list. Eg:

`user.groups = [ ldagrouphere, ldapgrouphere2, mozilliansorg_grouphere, workday_grouphere]`