### PR TITLE
Disable cis_whitelist, push only groups to auth0

### DIFF
--- a/functions/idvtoauth0/authzero.py
+++ b/functions/idvtoauth0/authzero.py
@@ -86,12 +86,39 @@ class CISAuthZero(object):
         user = DotDict(json.loads(res.read()))
         return user
 
+    def update_user_raw(self, user_id, attr):
+        """
+        user_id: string
+        groups: dict (of attributes)
+
+        Update the user's group structure directly. See update_user() to wrap the profile into app_metadata.
+        Returns the new user as a dict to the caller.
+        Auth0 API doc: https://auth0.com/docs/api/management/v2
+        Auth0 API endpoint: PATCH /api/v2/users/{id}
+        Auth0 API parameters: id (user_id, required), body (required)
+        """
+        payload = DotDict(dict())
+
+        # This validates the JSON as well
+        payload_json = json.dumps(payload)
+
+        self.conn.request("PATCH",
+                          "/api/v2/users/{}".format(user_id),
+                          payload_json,
+                          self._authorize(self.default_headers))
+        res = self.conn.getresponse()
+        self._check_http_response(res)
+        user = DotDict(json.loads(res.read()))
+        return user
+
     def update_user(self, user_id, new_profile):
         """
         user_id: string
         new_profile: dict (can be a JSON string loaded with json.loads(str) for example)
 
         Update a user in auth0 and return it as a dict to the caller.
+        This is done by updating user.app_metadata which is an attribute that Auth0 automatically re-integrate when
+        serving the profile through OIDC APIs, after rules have executed.
         Auth0 API doc: https://auth0.com/docs/api/management/v2
         Auth0 API endpoint: PATCH /api/v2/users/{id}
         Auth0 API parameters: id (user_id, required), body (required)
@@ -104,17 +131,7 @@ class CISAuthZero(object):
         if 'user_id' in new_profile.keys():
             del new_profile['user_id']
         payload.app_metadata = new_profile
-        # This validates the JSON as well
-        payload_json = json.dumps(payload)
-
-        self.conn.request("PATCH",
-                          "/api/v2/users/{}".format(user_id),
-                          payload_json,
-                          self._authorize(self.default_headers))
-        res = self.conn.getresponse()
-        self._check_http_response(res)
-        user = DotDict(json.loads(res.read()))
-        return user
+        return self.update_user_raw(user_id, payload)
 
     def get_access_token(self):
         """

--- a/functions/idvtoauth0/main.py
+++ b/functions/idvtoauth0/main.py
@@ -1,4 +1,8 @@
-""" This is the body of the lambda function """
+"""
+This is the body of the lambda function for the Auth0 Identity driver of CIS
+This function retrieves user profiles from the CIS ID Vault and sends the appropriate data to the Auth0 API
+which is in turn used to create the id_token JWT and fill the user info endpoint ('profile' scope)
+"""
 import authzero
 import boto3
 import credstash
@@ -30,24 +34,6 @@ def find_user(user_id):
 
     except ClientError:
         return None
-
-
-def _denullify_empty_values(data):
-    """
-    Opposite of https://github.com/akatsoulas/cis/blob/8c8da24b2c215d02f5e14dec7a94da6b1792c8c9/cis/publisher.py#L80
-    Remove `NULL` and replace it back by empty string
-    """
-    new = {}
-    for k in data.keys():
-        v = data[k]
-        if isinstance(v, dict):
-            v = _denullify_empty_values(v)
-        if v == 'NULL':
-            new[v] = ''
-        else:
-            new[v] = v
-    return new
-
 
 def handle(event, context):
     utils.StructuredLogger(
@@ -120,12 +106,9 @@ def handle(event, context):
                                 profile['groups'].append(g)
                                 logger.info("Forced re-integration of LDAP group {}".format(g))
 
-                   # XXX Force-convert `NULL` back to empty string, to accomodate the DynamoDB work-around found at:
-                   # https://github.com/akatsoulas/cis/blob/8c8da24b2c215d02f5e14dec7a94da6b1792c8c9/cis/publisher.py#L80
-                   # So that RP gets the correct value returned (which is empty string)
-                   # profile = _denullify_empty_values(profile)
-
-                    res = client.update_user(user_id, profile)
+                    profile_groups = {'groups': profile.get('groups')}
+                    res = client.update_user_raw(user_id, profile_groups)
+                    logger.info("Updating user group information in auth0 for {user_id}".format(user_id=user_id))
                 except Exception as e:
                     """Temporarily patch around raising inside loop until authzero.py can become part of CIS core."""
                     res = e


### PR DESCRIPTION
- adds a new function to update specific attributes only for the user in authzero lib
- utilize that function to only upgrade groups from the CIS Driver
- remove the nullification functions as it was already unused/commented out
- remove `cis_whitelist` check
- comments cleanup